### PR TITLE
Add Adonis Nextjs package

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 - [Adonis Apollo Server](https://github.com/ammezie/adonis-apollo-server) - Production-ready Node.js GraphQL server for AdonisJs
 - [Adonis Bumblebee](https://github.com/rhwilr/adonis-bumblebee) - Api Transformer for AdonisJs Framework
 - [Adonis SumoLogger](https://github.com/carlsonorozco/adonis-sumo-logger) - SumoLogic Driver Provider for AdonisJs Logger.
+- [Adonis Nextjs](https://github.com/omarkhatibco/adonis-nextjs) - A provider to initialize nextjs app with adonis.
 
 ## Articles, Tutorials, Blogs, etc.
 - [Adonis Official Blog](https://adonisjs.svbtle.com)


### PR DESCRIPTION
Adonis Nextjs package is a provider to initialize Nextjs app for React server side rendering