### PR TITLE
Add official discord link to the community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@
 
 - [Official Twitter](https://twitter.com/adonisframework)
 - [Official Forum](https://forum.adonisjs.com)
+- [Official Discord](https://discord.gg/vDcEjq6?)
 - [AdonisJS Georgia](https://www.facebook.com/groups/adonisjs.georgia/) - Facebook Group
 - [AdonisJS Philippines](https://www.facebook.com/groups/adonisjs.philippines/) - Facebook Group
 - [AdonisJS Indonesia](https://www.facebook.com/groups/1255340381204098/) - Facebook Group


### PR DESCRIPTION
I was very surprised to not see the official discord link in the community section as this has been a vital learning resource for me and the best way I saw to interact with the developers and the community